### PR TITLE
[Task] Add caution section for compose require

### DIFF
--- a/doc/01_Setup.md
+++ b/doc/01_Setup.md
@@ -44,7 +44,7 @@ Bugfix versions of Pimcore modules can be installed within a Platform Version vi
 
 - Carefully read our [Release Notes](./03_Release_Notes/README.md) before any update.
 - Update to a new Pimcore Platform version: 
-  - if you want to stick to a specific version, use the command `composer require pimcore/platform-version:2023.1`.
+  - if you want to update to a specific version, use the command `composer require pimcore/platform-version:2023.1 --no-update` to update your `composer.json`. Afterwards run `composer update`.
   - if you want to update to the latest version (and the constraint in your `composer.json` allows further updates), 
     use the command `composer update pimcore/platform-version`.
 

--- a/doc/01_Setup.md
+++ b/doc/01_Setup.md
@@ -57,7 +57,7 @@ Eventually adding `pimcore/*` is necessary for composer to resolve pimcore repos
 :::caution
 
 Keep in mind that the `pimcore/platform-version` repository does not specify required packages.  
-It only specifies conflicting packages to ensure only compatible versions are installed.
+It only specifies conflicting packages to ensure compatible versions are installed.
 The command `composer require pimcore/platform-version --update-with-all-dependencies` will therefore not work.
 The command `composer require` will check against your `composer.lock` and may result in an error.
 You need to run `composer update` to update all packages to the latest version.

--- a/doc/01_Setup.md
+++ b/doc/01_Setup.md
@@ -11,6 +11,7 @@ Use following steps to set up Pimcore Platform Version in an existing project:
   below to install further Pimcore modules. Eventually you need to adapt versions of other
   pimcore packages to apply to versions required by platform version. Please follow instructions of composer. 
 
+
 ### Setup with new project
 
 Use following steps to set up Pimcore Platform Version for a new project: 
@@ -51,6 +52,16 @@ Bugfix versions of Pimcore modules can be installed within a Platform Version vi
 :::tip
 
 Eventually adding `pimcore/*` is necessary for composer to resolve pimcore repository versions properly.
+
+:::
+
+:::caution
+
+Keep in mind that the `pimcore/platform-version` repository does not specify required packages.  
+It only specifies conflicting packages to ensure only compatible versions are installed.
+The command `composer require pimcore/platform-version --update-with-all-dependencies` will therefore not work.
+The command `composer require` will check against your `composer.lock` and may result in an error.
+You need to run `composer update` to update all packages to the latest version.
 
 :::
 

--- a/doc/01_Setup.md
+++ b/doc/01_Setup.md
@@ -11,7 +11,6 @@ Use following steps to set up Pimcore Platform Version in an existing project:
   below to install further Pimcore modules. Eventually you need to adapt versions of other
   pimcore packages to apply to versions required by platform version. Please follow instructions of composer. 
 
-
 ### Setup with new project
 
 Use following steps to set up Pimcore Platform Version for a new project: 


### PR DESCRIPTION
Resolves https://github.com/pimcore/service-operations/issues/14

Adding caution to update to new platform-version since there could be problems with composer require since platform-version only specifies conflicts but not required packages. Updating existing bundles can lead to a potential problem since  with composer require it is checked against the lock file and no update is requested for a specific bundles.