### PR TITLE
Install PimcoreStudioBackendBundle in script

### DIFF
--- a/.github/files/bundles.php
+++ b/.github/files/bundles.php
@@ -43,6 +43,7 @@ return [
     \Pimcore\Bundle\CopilotBundle\PimcoreCopilotBundle::class => ['all' => true],
 
     \Pimcore\Bundle\QuillBundle\PimcoreQuillBundle::class => ['all' => true],
+    \Pimcore\Bundle\StudioBackendBundle\PimcoreStudioBackendBundle::class => ['all' => true],
 ];
 
 

--- a/.github/scripts/02-install-pimcore.sh
+++ b/.github/scripts/02-install-pimcore.sh
@@ -63,6 +63,7 @@ docker compose exec -T php bin/console pimcore:bundle:install PimcoreDataHubWebh
 docker compose exec -T php bin/console pimcore:bundle:install PimcoreBackendPowerToolsBundle
 docker compose exec -T php bin/console pimcore:bundle:install PimcoreWorkflowAutomationIntegrationBundle
 docker compose exec -T php bin/console pimcore:bundle:install PimcoreCopilotBundle
+docker compose exec -T php bin/console pimcore:bundle:install PimcoreStudioBackendBundle
 
 cp ../../platform-version/.github/files/config-config.yaml ./config/local
 


### PR DESCRIPTION
feels like it has to be installed regardless

https://github.com/pimcore/platform-version/actions/runs/22732750740/job/65925929001#step:5:117
<img width="1540" height="146" alt="image" src="https://github.com/user-attachments/assets/fe014676-39be-4554-8c9b-007f21410032" />

or maybe is wrong here
https://github.com/pimcore/workflow-designer/blob/528cffe753171324dfbdd80338ae59654e9c33ea/src/DependencyInjection/PimcoreWorkflowDesignerExtension.php#L47-L49
