### PR TITLE
Update 2026.1 documentation to remove pre-release notes

### DIFF
--- a/doc/02_Pimcore_Platform/04_Platform_Versions/01_2026.1.md
+++ b/doc/02_Pimcore_Platform/04_Platform_Versions/01_2026.1.md
@@ -2,12 +2,6 @@
 
 Starting with Platform Version 2026.1, all module versions are synchronized with the platform version number.
 
-:::info
-
-This Platform Version has not been released yet. The module list below reflects the planned scope.
-
-:::
-
 The following table lists all Pimcore modules included in Platform Version 2026.1. Since all module versions are now synchronized, every module shows the same version number. The "Changed" column (✅) indicates modules with significant changes in this platform version release - check the release notes for details on what changed.
 
 | Package Name | Included Version | Changed |


### PR DESCRIPTION
Removed pre-release information and info box from the documentation.