### PR TITLE
Add fallback for issue-field IDs when org lookup is forbidden

### DIFF
--- a/.github/workflows/issue-fields-sync-bug.yml
+++ b/.github/workflows/issue-fields-sync-bug.yml
@@ -21,6 +21,8 @@ jobs:
       API_URL: ${{ github.api_url }}
       OWNER: ${{ github.repository_owner }}
       REPOSITORY: ${{ github.repository }}
+      CAPABILITY_FIELD_ID_FALLBACK: ${{ vars.ISSUE_FIELD_ID_AFFECTED_CAPABILITY }}
+      VERSION_FIELD_ID_FALLBACK: ${{ vars.ISSUE_FIELD_ID_PLATFORM_VERSION }}
     steps:
       - name: Resolve issue data
         id: resolve-issue
@@ -157,33 +159,44 @@ jobs:
             -H "X-GitHub-Api-Version: 2026-03-10" \
             "$API_URL/orgs/$OWNER/issue-fields")"
 
-          if [[ "$HTTP_CODE" != "200" ]]; then
+          if [[ "$HTTP_CODE" == "200" ]]; then
+            CAPABILITY_FIELD_ID="$(jq -r '.[] | select(.name == "Affected capability" and .data_type == "single_select") | .id' "$FIELD_RESPONSE_FILE" | head -n1)"
+            VERSION_FIELD_ID="$(jq -r '.[] | select(.name == "Platform Version" and .data_type == "single_select") | .id' "$FIELD_RESPONSE_FILE" | head -n1)"
+
+            if [[ -z "$CAPABILITY_FIELD_ID" || -z "$VERSION_FIELD_ID" || "$CAPABILITY_FIELD_ID" == "null" || "$VERSION_FIELD_ID" == "null" ]]; then
+              echo "Required single-select issue fields not found: 'Affected capability' and/or 'Platform Version'."
+              exit 1
+            fi
+
+            jq -e --arg value "$CAPABILITY" '
+              any(.[]; .name == "Affected capability" and any(.options[]?; .name == $value))
+            ' "$FIELD_RESPONSE_FILE" > /dev/null || {
+              echo "Capability option '$CAPABILITY' does not exist in issue field 'Affected capability'."
+              exit 1
+            }
+
+            jq -e --arg value "$PLATFORM_VERSION" '
+              any(.[]; .name == "Platform Version" and any(.options[]?; .name == $value))
+            ' "$FIELD_RESPONSE_FILE" > /dev/null || {
+              echo "Platform version option '$PLATFORM_VERSION' does not exist in issue field 'Platform Version'."
+              exit 1
+            }
+          elif [[ "$HTTP_CODE" == "403" ]]; then
+            echo "Org issue field lookup denied (HTTP 403). Falling back to repository variables."
+
+            CAPABILITY_FIELD_ID="$CAPABILITY_FIELD_ID_FALLBACK"
+            VERSION_FIELD_ID="$VERSION_FIELD_ID_FALLBACK"
+
+            if ! [[ "$CAPABILITY_FIELD_ID" =~ ^[0-9]+$ && "$VERSION_FIELD_ID" =~ ^[0-9]+$ ]]; then
+              echo "Fallback field IDs missing or invalid."
+              echo "Set repository variables: ISSUE_FIELD_ID_AFFECTED_CAPABILITY and ISSUE_FIELD_ID_PLATFORM_VERSION"
+              exit 1
+            fi
+          else
             echo "Failed to list org issue fields (HTTP $HTTP_CODE)."
             cat "$FIELD_RESPONSE_FILE"
             exit 1
           fi
-
-          CAPABILITY_FIELD_ID="$(jq -r '.[] | select(.name == "Affected capability" and .data_type == "single_select") | .id' "$FIELD_RESPONSE_FILE" | head -n1)"
-          VERSION_FIELD_ID="$(jq -r '.[] | select(.name == "Platform Version" and .data_type == "single_select") | .id' "$FIELD_RESPONSE_FILE" | head -n1)"
-
-          if [[ -z "$CAPABILITY_FIELD_ID" || -z "$VERSION_FIELD_ID" || "$CAPABILITY_FIELD_ID" == "null" || "$VERSION_FIELD_ID" == "null" ]]; then
-            echo "Required single-select issue fields not found: 'Affected capability' and/or 'Platform Version'."
-            exit 1
-          fi
-
-          jq -e --arg value "$CAPABILITY" '
-            any(.[]; .name == "Affected capability" and any(.options[]?; .name == $value))
-          ' "$FIELD_RESPONSE_FILE" > /dev/null || {
-            echo "Capability option '$CAPABILITY' does not exist in issue field 'Affected capability'."
-            exit 1
-          }
-
-          jq -e --arg value "$PLATFORM_VERSION" '
-            any(.[]; .name == "Platform Version" and any(.options[]?; .name == $value))
-          ' "$FIELD_RESPONSE_FILE" > /dev/null || {
-            echo "Platform version option '$PLATFORM_VERSION' does not exist in issue field 'Platform Version'."
-            exit 1
-          }
 
           echo "capability_field_id=$CAPABILITY_FIELD_ID" >> "$GITHUB_OUTPUT"
           echo "version_field_id=$VERSION_FIELD_ID" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- keep current org issue-fields lookup as primary path
- add fallback to repo variables when org endpoint returns 403
- support vars ISSUE_FIELD_ID_AFFECTED_CAPABILITY and ISSUE_FIELD_ID_PLATFORM_VERSION

## Why
In this repo, GITHUB_TOKEN cannot access org issue-fields endpoint, causing workflow failure with 403.
