### PR TITLE
Rework skeleton getting-started docs for the new installer (#19179)

### DIFF
--- a/doc/03_Getting_Started/01_Installation/00_Skeleton_Installation.md
+++ b/doc/03_Getting_Started/01_Installation/00_Skeleton_Installation.md
@@ -1,141 +1,117 @@
 # Skeleton Installation
 
-The skeleton package provides a minimal Pimcore setup.
-The install profile includes Pimcore Studio and its dependencies (GenericExecutionEngine,
-GenericDataIndex, StudioBackend, StudioUI, DataHub), so you do not need to install them separately.
+The skeleton is a minimal Pimcore project for building from scratch. It already includes Pimcore
+Studio and ships a ready-to-run Docker environment, so you can get a working instance in four steps.
 
-## Step 1: Create the Project
+## Installation
 
-Create the project using the Pimcore Docker image:
+### 1. Create the project
 
 ```bash
 docker run -u `id -u`:`id -g` --rm -v `pwd`:/var/www/html pimcore/pimcore:php8.5-latest composer create-project pimcore/skeleton --no-scripts my-project
-```
-
-Switch to the project directory:
-
-```bash
 cd my-project/
 ```
 
-## Step 2: Configure Docker Services
+### 2. Start the services
 
-The skeleton includes a `docker-compose.yaml` with the base services (PHP, Nginx, MariaDB, Redis).
-Pimcore Studio requires two additional services:
-OpenSearch (or Elasticsearch) for search indexing, and Mercure for real-time updates.
-
-1. Run `` echo `id -u`:`id -g` `` to retrieve your local user and group ID.
-2. Open `docker-compose.yaml`, uncomment all `user: '1000:1000'` lines,
-   and update the IDs if they differ from your local user.
-3. Add the OpenSearch and Mercure services to your `docker-compose.yaml`:
-
-```yaml
-services:
-  # ... existing services (php, nginx, db, redis) ...
-
-  opensearch:
-    image: opensearchproject/opensearch:2.19.2
-    environment:
-      - cluster.name=opensearch-cluster
-      - node.name=opensearch
-      - discovery.type=single-node
-      - bootstrap.memory_lock=true
-      - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m
-      - DISABLE_INSTALL_DEMO_CONFIG=true
-      - DISABLE_SECURITY_PLUGIN=true
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-      nofile:
-        soft: 65536
-        hard: 65536
-    volumes:
-      - opensearch-data:/usr/share/opensearch/data
-
-  mercure:
-    image: dunglas/mercure:latest
-    restart: unless-stopped
-    environment:
-      SERVER_NAME: ':80'
-      MERCURE_PUBLISHER_JWT_KEY: 'YourMercureJwtKeyMustBeAtLeast256BitsLong!'
-      MERCURE_SUBSCRIBER_JWT_KEY: 'YourMercureJwtKeyMustBeAtLeast256BitsLong!'
-    expose:
-      - "80"
-    volumes:
-      - mercure-data:/data
-      - mercure-config:/config
-
-volumes:
-  # ... existing volumes ...
-  opensearch-data:
-  mercure-data:
-  mercure-config:
-```
-
-:::info
-
-The Mercure JWT key must be at least 256 bits (32 characters) long.
-Use the same key in both the Docker configuration and the Pimcore application configuration.
-Keep this key private.
-
-:::
-
-4. Add a reverse proxy rule for Mercure in your Nginx configuration
-   (e.g. `.docker/nginx.conf` in the skeleton) so the browser can reach the Mercure hub:
-
-```conf
-location /hub {
-    proxy_pass http://mercure/.well-known/mercure;
-}
-```
-
-5. Start all services:
+Match the container user to your local user, then start everything:
 
 ```bash
+sed -i "s|user: '1000:1000'|user: '$(id -u):$(id -g)'|g" docker-compose.yaml
 docker compose up -d
 ```
 
-## Step 3: Run the Installer
-
-Run the Pimcore installer with the skeleton profile:
+### 3. Run the installer
 
 ```bash
-docker compose exec php vendor/bin/pimcore-install \
-  --install-profile='App\Installer\SkeletonProfile'
+docker compose exec php vendor/bin/pimcore-install --install-profile='App\Installer\SkeletonProfile'
 ```
 
-The installer will interactively prompt for all required configuration values:
-database connection, messenger transport, admin credentials,
-and product registration.
+The skeleton's `.env` already holds every connection and credential, so the installer only prompts
+for a **product key** (product registration is mandatory — it prints a registration link). Everything
+else, including building the search index, runs automatically.
 
-During installation, you will be prompted to register your Pimcore instance.
-Product registration is mandatory, and installation cannot proceed without a valid product key.
-The installer provides a link to the registration form.
-See [Product Registration](../02_Product_Registration.md) for details.
-
-The installer automatically:
-- Writes all configuration to `.env.local`
-- Installs and registers all bundles defined in the profile
-- Creates the database schema and admin user
-- Installs assets, builds search indices, and runs all post-install commands
-
-For non-interactive (CI) installations, set env vars in `.env` or `docker-compose.yaml`
-before running the installer with `--no-interaction`.
-See [Advanced Installation Topics](./03_Advanced_Installation_Topics/README.md)
-for the full list of supported environment variables.
-
-## Step 4: Configure Pimcore Studio
-
-The installer handles bundle installation and environment variable configuration,
-but some YAML configuration files must be set up manually.
-
-Follow the [Pimcore Studio Setup](./03_Advanced_Installation_Topics/02_Pimcore_Studio_Setup.md)
-guide to learn more about configuring OpenSearch, the security firewall, Mercure, and messenger transports.
-
-## Step 5: Done
-
-Visit your Pimcore instance:
+### 4. Open Pimcore
 
 - Frontend: [http://localhost](http://localhost)
-- Pimcore Studio: [http://localhost/pimcore-studio](http://localhost/pimcore-studio)
+- Pimcore Studio: [http://localhost/pimcore-studio](http://localhost/pimcore-studio) — log in with `admin` / `admin`
+
+:::caution
+
+The shipped credentials and secrets are insecure development placeholders. Change them before any
+shared or production deployment — see [Production hardening](#production-hardening) below.
+
+:::
+
+## Additional Information
+
+### What's pre-configured
+
+The committed `docker-compose.yaml` defines every service Pimcore needs — PHP, Nginx, MariaDB,
+Redis, RabbitMQ, OpenSearch (plus OpenSearch Dashboards), Mercure, and a Supervisord service that
+runs the messenger workers. The matching configuration ships too (`.env`, the `.docker/` files, and
+the YAML under `config/`), so the OpenSearch client, security firewall, Mercure, and messenger
+transports are already wired up. You do not need to add or configure these yourself.
+
+:::caution
+
+Do not replace the bundled `opensearch` and `mercure` containers with definitions from other
+guides — `.env` and `config/` are wired to the bundled ones. In particular, the bundled OpenSearch
+runs with the security plugin enabled over HTTPS
+(`PIMCORE_OPENSEARCH_DSN=opensearch://admin:...@opensearch:9200?ssl=true&ssl_verify=false`).
+Swapping in a plain-HTTP OpenSearch breaks installation and indexing.
+
+:::
+
+### What the installer does
+
+Because `.env` already provides the database, OpenSearch, RabbitMQ, Mercure, admin, and
+application-secret values, the installer validates them (connecting to the database, pinging
+OpenSearch) instead of prompting, then:
+
+- Writes the resolved configuration to `.env.local`
+- Installs and registers the profile's bundles and their assets
+- Creates the database schema and the `admin` user
+- Runs all post-install commands, including building the search index
+
+For non-interactive (CI) installs, provide the product-registration values as environment variables
+and add `--no-interaction`. See [Advanced Installation Topics](./03_Advanced_Installation_Topics/README.md)
+for the full list of environment variables, and
+[Pimcore Studio Setup](./03_Advanced_Installation_Topics/02_Pimcore_Studio_Setup.md) to understand
+or customize the Studio configuration.
+
+### Default credentials and product registration
+
+The default login is `admin` / `admin` (from `PIMCORE_ADMIN_USER` / `PIMCORE_ADMIN_PASSWORD` in
+`.env`). Because they are pre-set, the installer does not ask you to choose them; to be prompted
+instead, remove those two lines before installing.
+
+Product registration is mandatory. The installer auto-generates the instance identifier and
+encryption secret and prompts only for the product key.
+See [Product Registration](../02_Product_Registration.md).
+
+### Rebuilding the search index
+
+The index is built during installation. To rebuild it later (for example after changing the index
+configuration):
+
+```bash
+docker compose exec php bin/console generic-data-index:update:index -r
+```
+
+The `-r` flag recreates the indices from scratch; the Supervisord service keeps them up to date as
+you create and edit elements.
+
+### Production hardening
+
+The skeleton is configured for local development. Before deploying anywhere shared or public,
+replace all placeholder secrets with strong, private values — the admin login (`admin` / `admin`),
+the database and OpenSearch passwords, the Mercure JWT key (`CHANGE_ME_...`), and the
+`APPLICATION_SECRET`. Once you use a trusted certificate, also drop `ssl_verify=false` from the
+OpenSearch DSN.
+
+### First steps in Studio
+
+A fresh skeleton has no homepage document, so [http://localhost](http://localhost) shows the
+built-in example page. Create your first document in Studio to replace it — see
+[Create a First Project](../03_Create_a_First_Project/README.md).

--- a/doc/03_Getting_Started/01_Installation/03_Advanced_Installation_Topics/02_Pimcore_Studio_Setup.md
+++ b/doc/03_Getting_Started/01_Installation/03_Advanced_Installation_Topics/02_Pimcore_Studio_Setup.md
@@ -10,43 +10,57 @@ It consists of four bundles:
 
 :::info
 
-The demo enterprise package (`pimcore/demo-enterprise`) ships with all Studio bundles pre-installed
-and pre-configured. This page applies only to skeleton-based installations.
+The `pimcore/skeleton` and `pimcore/demo-enterprise` packages already ship Pimcore Studio
+**pre-configured** — the bundles are registered, the OpenSearch client, security firewall,
+Mercure wiring, and messenger transports are all set up in the committed `config/` and `.docker/`
+files, and the Docker environment includes every required service. For a standard skeleton
+install you do not need to change any of the configuration on this page.
+
+This page documents what the skeleton ships and where, so you can understand or customize it.
+It is also a reference for adding Studio to a project that was **not** based on the skeleton.
 
 :::
 
 ## Prerequisites
 
-Before running the installer, your Docker environment must include:
+Pimcore Studio needs the following services. The skeleton's `docker-compose.yaml` already provides them:
 
 - **OpenSearch >= 2.7** (or Elasticsearch >= 8.0.0) for search indexing
 - **Mercure** for real-time updates in the Studio interface
 
-See the [Skeleton Installation](../00_Skeleton_Installation.md) guide for Docker service configuration.
+See the [Skeleton Installation](../00_Skeleton_Installation.md) guide for the Docker setup.
 
 ## Bundle Installation
 
-The Skeleton install profile includes all four Studio bundles. When you run the installer
-with `--install-profile='App\Installer\SkeletonProfile'`, it automatically:
+The Skeleton install profile (`App\Installer\SkeletonProfile`) lists all Studio bundles. When you run
+the installer, it automatically:
 
-- Installs the required Composer packages
-- Registers all bundles in `config/bundles.php`
+- Registers the bundles in `config/bundles.php`
 - Runs `pimcore:bundle:install` for each bundle
-- Writes connection details (OpenSearch, Mercure, messenger transport) to `.env.local`
-- Builds the search index
+- Installs bundle assets
 
-No manual `composer require`, `bundles.php` editing, or `pimcore:bundle:install` commands are needed.
+The connection details (OpenSearch, Mercure, messenger transport) come from environment variables
+that are already set in the skeleton's committed `.env` and validated by the installer. No manual
+`composer require`, `bundles.php` editing, or `pimcore:bundle:install` commands are needed.
 
 ## OpenSearch Configuration
 
-The OpenSearch client bundle ships with a default configuration that reads the connection
-URL from the `PIMCORE_OPENSEARCH_DSN` environment variable (written by the installer).
-The GenericDataIndex bundle defaults to using the `default` client with OpenSearch.
+The GenericDataIndex bundle reads the OpenSearch connection from the `PIMCORE_OPENSEARCH_DSN`
+environment variable and defaults to the `default` client with OpenSearch. The skeleton sets this
+in `.env`, pointing at the bundled OpenSearch service:
 
-**In most cases, no manual YAML configuration is needed.**
+```dotenv
+PIMCORE_OPENSEARCH_DSN=opensearch://admin:gBsVe!Dut723@opensearch:9200?ssl=true&ssl_verify=false
+```
 
-If you need to customize the OpenSearch connection (e.g., multiple clients, authentication,
-or a different client name), override the defaults in `config/config.yaml`:
+The bundled OpenSearch runs with the security plugin enabled, so the DSN uses the `opensearch://`
+scheme, includes the admin credentials, and enables TLS (`ssl=true`). `ssl_verify=false` accepts the
+service's self-signed certificate in local development.
+
+**No manual YAML configuration is needed for the skeleton.**
+
+If you need to customize the OpenSearch connection (for example multiple clients, different
+credentials, or a different client name), override the defaults in `config/config.yaml`:
 
 ```yaml
 pimcore_open_search_client:
@@ -62,34 +76,39 @@ pimcore_generic_data_index:
 
 :::tip
 
-If you use Elasticsearch instead of OpenSearch, see the
+If you use Elasticsearch instead of OpenSearch, set `PIMCORE_ELASTICSEARCH_DSN`
+(scheme `elasticsearch://`) and see the
 [Generic Data Index configuration documentation](https://github.com/pimcore/generic-data-index-bundle/blob/2026.x/doc/02_Configuration/05_Elasticsearch.md)
 for the equivalent setup.
 
 :::
 
-## Configure Security Firewall
+## Security Firewall
 
-Add the Studio Backend firewall settings to `config/packages/security.yaml`.
-Place the `pimcore_studio` firewall before the `main` firewall,
-since Symfony evaluates firewalls in order:
+The skeleton already ships the Studio Backend firewall in `config/packages/security.yaml`.
+The `pimcore_studio` firewall is placed before the `main` firewall, since Symfony evaluates
+firewalls in order. The committed configuration looks like this:
 
 ```yaml
 security:
     firewalls:
-        pimcore_studio: '%pimcore_studio_backend.firewall_settings%'
+        pimcore_studio: "%pimcore_studio_backend.firewall_settings%"
+
     access_control:
-        - { path: ^/pimcore-studio/api/(docs|docs/json|translations|user/reset-password)$, roles: PUBLIC_ACCESS }
+        - {
+            path: ^/pimcore-studio/api/(docs|docs/json|translations|user/reset-password|setting/admin/thumbnail)$,
+            roles: PUBLIC_ACCESS,
+        }
         - { path: ^/pimcore-studio/api, roles: ROLE_PIMCORE_USER }
 ```
+
+If you are adding Studio to a non-skeleton project, add the same firewall and access-control rules.
 
 ## Mercure Configuration
 
 Mercure enables real-time updates in Pimcore Studio (progress tracking, live notifications).
-The installer writes `MERCURE_JWT_KEY`, `MERCURE_URL`, and `MERCURE_SERVER_URL` to `.env.local`.
-
-Wire these environment variables to the Studio Backend configuration
-in `config/config.yaml`:
+The skeleton sets `MERCURE_JWT_KEY`, `MERCURE_URL`, and `MERCURE_SERVER_URL` in `.env`, and
+already wires them to the Studio Backend in `config/config.yaml`:
 
 ```yaml
 pimcore_studio_backend:
@@ -102,11 +121,25 @@ pimcore_studio_backend:
 | Setting | Env Var | Description |
 |---------|---------|-------------|
 | `jwt_key` | `MERCURE_JWT_KEY` | Must match the key configured in the Mercure Docker service. Minimum 256 bits (32 characters). |
-| `hub_url_client` | `MERCURE_URL` | The URL the browser uses to connect to Mercure (through the Nginx reverse proxy). |
-| `hub_url_server` | `MERCURE_SERVER_URL` | The internal Docker URL used by the PHP application to publish messages. |
+| `hub_url_client` | `MERCURE_URL` | The URL the browser uses to connect to Mercure (through the Nginx reverse proxy, e.g. `http://localhost/hub`). |
+| `hub_url_server` | `MERCURE_SERVER_URL` | The internal Docker URL the PHP application uses to publish messages (e.g. `http://mercure/.well-known/mercure`). |
 
-If `hub_url_client` and `hub_url_server` are not configured, URLs are generated based
-on the current Pimcore host and default paths.
+:::info
+
+The Mercure JWT key must be at least 256 bits (32 characters) long. The same key must be used in
+both the Mercure Docker service and `MERCURE_JWT_KEY`. The skeleton ships a placeholder key
+(`CHANGE_ME_...`); replace it with your own private key before any non-local deployment.
+
+:::
+
+The skeleton's `.docker/nginx.conf` already exposes the Mercure hub under `/hub` (same-origin,
+no CORS needed):
+
+```conf
+location /hub {
+    proxy_pass http://mercure/.well-known/mercure;
+}
+```
 
 ### Optional Mercure Settings
 
@@ -137,11 +170,8 @@ For advanced Mercure configuration (external URLs, CORS, Apache reverse proxy, d
 
 ## Messenger Transports
 
-Pimcore core and the Studio bundles auto-configure all required messenger transports using the
-`PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX` environment variable (written by the installer).
-
-**No manual transport YAML configuration is needed.** The following transports are
-registered automatically by the bundles:
+Pimcore core and the Studio bundles auto-configure the required messenger transports. The
+following transports are registered automatically by the bundles:
 
 | Transport | Registered By |
 |-----------|---------------|
@@ -153,36 +183,45 @@ registered automatically by the bundles:
 | `pimcore_generic_execution_engine` | GenericExecutionEngineBundle |
 | `pimcore_generic_data_index_queue` | GenericDataIndexBundle |
 
-All transports use `%pimcore.messenger.transport_dsn_prefix%` which resolves from the
-`PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX` env var. For example, with the default Doctrine
-transport, the prefix `doctrine://default?queue_name=` produces DSNs like
-`doctrine://default?queue_name=pimcore_core`.
+The skeleton uses **RabbitMQ (AMQP)** as the transport backend. The DSN prefix is set in `.env`:
+
+```dotenv
+PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX=amqp://guest:guest@rabbitmq:5672/%2f/
+```
+
+Each transport's full DSN is formed by appending the queue name to this prefix, for example
+`amqp://guest:guest@rabbitmq:5672/%2f/pimcore_core`. The skeleton additionally pins the core
+transports to RabbitMQ in `.docker/messenger.yaml` (mounted over `config/packages/messenger.yaml`).
 
 See [Symfony Messenger](./01_Symfony_Messenger.md) for details on switching transport
 backends (Doctrine, AMQP, Redis).
 
-## Start Messenger Workers
+## Messenger Workers
 
-The messenger transports require active workers to process background jobs (search indexing, execution engine tasks).
+The messenger transports require active workers to process background jobs (search indexing,
+execution engine tasks).
 
-For development, start workers manually:
+**In the skeleton, workers run automatically.** The `supervisord` service in `docker-compose.yaml`
+starts the consumers for you (see `.docker/supervisord.conf`), consuming all queues:
 
-```bash
-docker compose exec php bin/console messenger:consume pimcore_generic_execution_engine pimcore_generic_data_index_queue
+```
+pimcore_generic_data_index_queue scheduler_generic_data_index pimcore_core pimcore_maintenance
+pimcore_scheduled_tasks pimcore_image_optimize pimcore_asset_update pimcore_generic_execution_engine
 ```
 
-The Generic Data Index bundle also registers a `scheduler_generic_data_index` scheduler for periodic tasks.
-To include it:
+If you run Pimcore **without** the bundled Supervisord service, start the workers manually instead:
 
 ```bash
-docker compose exec php bin/console messenger:consume pimcore_generic_execution_engine pimcore_generic_data_index_queue scheduler_generic_data_index
+docker compose exec php bin/console messenger:consume \
+  pimcore_generic_execution_engine pimcore_generic_data_index_queue scheduler_generic_data_index \
+  pimcore_core pimcore_maintenance pimcore_scheduled_tasks pimcore_image_optimize pimcore_asset_update
 ```
 
-For production, use Supervisord to run messenger workers as daemons. Example supervisor configuration:
+For production, run the workers as daemons under Supervisord. Example program definition:
 
 ```ini
 [program:pimcore-messenger]
-command=php /var/www/html/bin/console messenger:consume pimcore_generic_execution_engine pimcore_generic_data_index_queue scheduler_generic_data_index --memory-limit=250M --time-limit=3600
+command=php /var/www/html/bin/console messenger:consume pimcore_generic_execution_engine pimcore_generic_data_index_queue scheduler_generic_data_index pimcore_core pimcore_maintenance pimcore_scheduled_tasks pimcore_image_optimize pimcore_asset_update --memory-limit=250M --time-limit=3600
 numprocs=1
 startsecs=0
 autostart=true
@@ -190,25 +229,37 @@ autorestart=true
 process_name=%(program_name)s_%(process_num)02d
 ```
 
+:::caution
+
+Only consume queues that actually exist. Passing an unregistered queue name (for example the
+removed `pimcore_index_queues`) makes `messenger:consume` fail with
+*"The receiver ... does not exist"* and the worker restarts in a loop. The valid queue names are
+the ones listed in the table above plus the `scheduler_generic_data_index` scheduler.
+
+:::
+
 See the [Symfony Messenger deployment documentation](https://symfony.com/doc/current/messenger.html#deploying-to-production) for more options.
 
 ## Build the Search Index
 
-The installer automatically builds the search index during installation via
-the `generic-data-index:update:index -r` post-install command.
+The GenericDataIndex bundle registers `generic-data-index:update:index -r` as a post-install
+command, so the installer builds the search index automatically during installation. No manual
+step is needed for a fresh install.
 
-If you need to rebuild the index later (e.g. after configuration changes), run:
+To rebuild the index later (for example after changing the index configuration), run:
 
 ```bash
 docker compose exec php bin/console generic-data-index:update:index -r
 ```
 
-The `-r` flag recreates the indices from scratch.
-This command creates the OpenSearch/Elasticsearch indices and queues all assets and data objects for indexing.
+The `-r` flag recreates the indices from scratch. This command creates the OpenSearch/Elasticsearch
+indices and queues all assets and data objects for indexing; the messenger workers then process the
+queue. Until the indices exist, Studio may show empty trees or return errors.
 
 ## Verify the Installation
 
 Navigate to [http://localhost/pimcore-studio](http://localhost/pimcore-studio).
-You should see the Pimcore Studio login screen.
+You should see the Pimcore Studio login screen, and you can log in with the admin credentials from
+`.env` (default `admin` / `admin`).
 
-The Studio Backend also provides an OpenAPI documentation at `/pimcore-studio/api/docs` for exploring the REST API.
+The Studio Backend also provides OpenAPI documentation at `/pimcore-studio/api/docs` for exploring the REST API.

--- a/doc/03_Getting_Started/01_Installation/03_Advanced_Installation_Topics/README.md
+++ b/doc/03_Getting_Started/01_Installation/03_Advanced_Installation_Topics/README.md
@@ -60,8 +60,8 @@ If a variable is not set for an optional service, the installer skips that servi
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `PIMCORE_OPENSEARCH_DSN` | OpenSearch connection URL | `http://opensearch:9200` |
-| `PIMCORE_ELASTICSEARCH_DSN` | Elasticsearch connection URL | `http://elasticsearch:9200` |
+| `PIMCORE_OPENSEARCH_DSN` | OpenSearch connection DSN (scheme `opensearch://`) | `opensearch://admin:pass@opensearch:9200?ssl=true&ssl_verify=false` |
+| `PIMCORE_ELASTICSEARCH_DSN` | Elasticsearch connection DSN (scheme `elasticsearch://`) | `elasticsearch://elastic:pass@elasticsearch:9200?ssl=true&ssl_verify=true` |
 | `PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX` | Messenger transport DSN with trailing separator | `doctrine://default?queue_name=` |
 | `REDIS_URL` | Redis connection URL for cache | `redis://redis:6379` |
 | `MAILER_DSN` | Symfony Mailer DSN | `smtp://mail:1025` |

--- a/doc/03_Getting_Started/01_Installation/README.md
+++ b/doc/03_Getting_Started/01_Installation/README.md
@@ -19,10 +19,11 @@ Pimcore offers two installation packages:
 | **`pimcore/skeleton`** | Empty project for building from scratch. Best for starting a new implementation. | [Skeleton Installation](./00_Skeleton_Installation.md) |
 | **`pimcore/demo-enterprise`** | Pre-built project with enterprise blueprints showcasing advanced features. Requires Pimcore enterprise repository credentials. | [Demo Enterprise Installation](./01_Demo_Enterprise_Installation.md) |
 
-Both packages use the same profile-based installer. The installer interactively collects all
-required configuration (database, search engine, Mercure, product registration),
-writes environment variables to `.env.local`, installs bundles, and runs all necessary
-post-installation commands automatically.
+Both packages use the same profile-based installer and ship a pre-configured Docker environment
+together with a pre-filled `.env`. The installer reads those values, prompts only for what is not
+yet provided (typically product registration), writes the resolved configuration to `.env.local`,
+installs and registers bundles, and runs post-install commands (including building the search
+index), so the instance is usable right away.
 
 For automated (CI) installations, see [Advanced Installation Topics](./03_Advanced_Installation_Topics/README.md).
 


### PR DESCRIPTION
## Summary

Reworks the Getting Started / Installation docs so they match what the `pimcore/skeleton` package
actually ships and how the new profile-based installer behaves. Addresses the documentation issues
reported in pimcore/pimcore#19179.

The skeleton already ships a fully pre-configured Docker environment (`docker-compose.yaml` with
OpenSearch, Mercure, RabbitMQ, Redis, Supervisord), a pre-filled `.env`, and the matching `config/`
and `.docker/` files — but the docs still instructed users to add those services and configuration
themselves, which conflicted with the shipped setup and broke installation.

## Changes

- **Skeleton Installation** — restructured into a lean four-step happy path plus an
  *Additional Information* reference section. Documents that `.env` is pre-filled (so the installer
  only prompts for the product key), that the search index is built automatically, default
  `admin`/`admin` credentials, and production hardening.
- **Pimcore Studio Setup** — reframes the OpenSearch client, security firewall, Mercure wiring, and
  messenger transports as *already configured* in the skeleton. Fixes the OpenSearch DSN to the
  `opensearch://…?ssl=true` scheme, notes that the Supervisord service runs the workers
  automatically, and documents the valid queue names (the removed `pimcore_index_queues` was the
  cause of the worker crash loop in the issue).
- **Installation overview / Advanced Installation Topics** — corrected the OpenSearch/Elasticsearch
  DSN examples and the installer-behavior wording.

## Notes

The Studio "unauthorized / no create-context-menu" symptom in the issue was rooted in the
misconfigured (plain-HTTP) OpenSearch from the old docs plus the now-fixed wrong queue name; these
doc changes address the setup path. No application code is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
