### PR TITLE
Sbom docs

### DIFF
--- a/doc/02_Pimcore_Platform/04_Platform_Versions/01_2026.1.md
+++ b/doc/02_Pimcore_Platform/04_Platform_Versions/01_2026.1.md
@@ -41,6 +41,6 @@ The following table lists all Pimcore modules included in Platform Version 2026.
 
 ## Software Bill of Materials (SBOM)
 
-The SBOM is generated automatically by a GitHub Actions workflow. You can browse the workflow runs and download the generated SBOM for the Platform Version here:
+The SBOM (CycloneDX JSON) is generated automatically by a GitHub Actions workflow and attached to the corresponding GitHub release. You can download the SBOM for this Platform Version here:
 
-[SBOM generation workflow](https://github.com/pimcore/platform-version/actions/workflows/sbom.yaml)
+[sbom.json for 2026.1](https://github.com/pimcore/platform-version/releases/download/v2026.1.0/sbom.json)

--- a/doc/02_Pimcore_Platform/04_Platform_Versions/01_2026.1.md
+++ b/doc/02_Pimcore_Platform/04_Platform_Versions/01_2026.1.md
@@ -38,3 +38,9 @@ The following table lists all Pimcore modules included in Platform Version 2026.
 | [pimcore/web-to-print-bundle](https://github.com/pimcore/ee-web-to-print-bundle) (Enterprise) | 2026.1 | ✅ |
 | [pimcore/workflow-automation-integration-bundle](https://github.com/pimcore/workflow-automation-integration-bundle) (Enterprise) | 2026.1 | ✅ |
 | [pimcore/workflow-designer](https://github.com/pimcore/workflow-designer) (Enterprise) | 2026.1 | ✅ |
+
+## Software Bill of Materials (SBOM)
+
+The SBOM is generated automatically by a GitHub Actions workflow. You can browse the workflow runs and download the generated SBOM for the Platform Version here:
+
+[SBOM generation workflow](https://github.com/pimcore/platform-version/actions/workflows/sbom.yaml)

--- a/doc/02_Pimcore_Platform/04_Platform_Versions/README.md
+++ b/doc/02_Pimcore_Platform/04_Platform_Versions/README.md
@@ -44,18 +44,18 @@ import VersionTimeline from '@site/src/components/VersionTimeline';
 
 ## Platform Version Releases
 
-| Version | Release Notes | Module Details | LTS | LTS Support Until |
-|---------|--------------|----------------|:---:|-------------------|
-| 2026.1  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/01_2026.1/README.md) | [Details](01_2026.1.md) | | |
-| 2025.4  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/02_2025.4.md) | [Details](02_2025.4.md) | ✅ | December 2028 |
-| 2025.3  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/03_2025.3.md) | [Details](03_2025.3.md) | | |
-| 2025.2  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/04_2025.2.md) | [Details](04_2025.2.md) | | |
-| 2025.1  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/05_2025.1.md) | [Details](05_2025.1.md) | | |
-| 2024.4  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/06_2024.4.md) | [Details](06_2024.4.md) | ✅ | December 2026 |
-| 2024.3  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/07_2024.3.md) | [Details](07_2024.3.md) | | |
-| 2024.2  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/08_2024.2.md) | [Details](08_2024.2.md) | | |
-| 2024.1  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/09_2024.1.md) | [Details](09_2024.1.md) | | |
-| 2023.3  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/10_2023.3.md) | [Details](10_2023.3.md) | ✅ | December 2025 |
-| 2023.2  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/11_2023.2.md) | [Details](11_2023.2.md) | | |
-| 2023.1  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/12_2023.1.md) | [Details](12_2023.1.md) | | |
-| 2022.0  | - | [Details](13_2022.0.md) | ✅ | August 2025 |
+| Version | Release Notes | Module Details | SBOM | LTS | LTS Support Until |
+|---------|--------------|----------------|------|:---:|-------------------|
+| 2026.1  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/01_2026.1/README.md) | [Details](01_2026.1.md) | [SBOM](https://github.com/pimcore/platform-version/actions/workflows/sbom.yaml) | | |
+| 2025.4  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/02_2025.4.md) | [Details](02_2025.4.md) | - | ✅ | December 2028 |
+| 2025.3  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/03_2025.3.md) | [Details](03_2025.3.md) | - | | |
+| 2025.2  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/04_2025.2.md) | [Details](04_2025.2.md) | - | | |
+| 2025.1  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/05_2025.1.md) | [Details](05_2025.1.md) | - | | |
+| 2024.4  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/06_2024.4.md) | [Details](06_2024.4.md) | - | ✅ | December 2026 |
+| 2024.3  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/07_2024.3.md) | [Details](07_2024.3.md) | - | | |
+| 2024.2  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/08_2024.2.md) | [Details](08_2024.2.md) | - | | |
+| 2024.1  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/09_2024.1.md) | [Details](09_2024.1.md) | - | | |
+| 2023.3  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/10_2023.3.md) | [Details](10_2023.3.md) | - | ✅ | December 2025 |
+| 2023.2  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/11_2023.2.md) | [Details](11_2023.2.md) | - | | |
+| 2023.1  | [Release Notes](../05_Updating_Pimcore/02_Release_Notes/12_2023.1.md) | [Details](12_2023.1.md) | - | | |
+| 2022.0  | - | [Details](13_2022.0.md) | - | ✅ | August 2025 |


### PR DESCRIPTION
This pull request updates the documentation for Pimcore Platform Versions to include information about the Software Bill of Materials (SBOM) for version 2026.1. It introduces a new SBOM section in the detailed version documentation and adds an SBOM column with download links to the platform version summary table.

**Documentation updates for SBOM:**

* Added a new "Software Bill of Materials (SBOM)" section to `01_2026.1.md`, explaining how to access the SBOM generated by GitHub Actions for version 2026.1.
* Updated the platform version summary table in `README.md` to include a new "SBOM" column, with a direct link to the SBOM for version 2026.1.