### PR TITLE
Exclude empty and inaccessible repos from CONTRIBUTING.md sync

### DIFF
--- a/.github/workflows/sync-pr-guidelines.yml
+++ b/.github/workflows/sync-pr-guidelines.yml
@@ -24,8 +24,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          repos=$(gh repo list pimcore --no-archived --source --limit 1000 --json nameWithOwner \
-            --jq '.[].nameWithOwner' | grep -v '^pimcore/platform-version$')
+          repos=$(gh repo list pimcore --no-archived --source --limit 1000 --json nameWithOwner,defaultBranchRef \
+            --jq '.[] | select(.defaultBranchRef.name != "") | .nameWithOwner' | grep -vE '^pimcore/(platform-version|poca|k8s-bases)$')
 
           {
             echo "group:"


### PR DESCRIPTION
Skips repos with no default branch (frontend-tests, planning) and repos the sync token can't write to (poca, k8s-bases).