### PR TITLE
[self-heal] Fix Tests failure in API Tests

### DIFF
--- a/.github/scripts/01-setup-environment.sh
+++ b/.github/scripts/01-setup-environment.sh
@@ -92,7 +92,7 @@ fi
 mkdir -p "${PROJECT_PATH}/.docker"
 cp "${FILES_DIR}/nginx.conf"      "${PROJECT_PATH}/.docker/nginx.conf"
 cp "${FILES_DIR}/supervisord.conf" "${PROJECT_PATH}/.docker/supervisord.conf"
-cp "${FILES_DIR}/messenger.yaml"   "${PROJECT_PATH}/config/packages/messenger.yaml"
+cp "${FILES_DIR}/messenger.yaml"   "${PROJECT_PATH}/.docker/messenger.yaml"
 
 # Write project .env.local
 cat > "${PROJECT_PATH}/.env.local" <<ENVEOF


### PR DESCRIPTION
## Automated self-healing fix

> :warning: Auto-generated by the self-healing workflow. **Needs human review — do not merge without verifying.**

**Repository:** `pimcore/platform-version`
**Workflow:** API Tests (Tests)
**Branch:** `2026.x`
**Failed run:** https://github.com/pimcore/platform-version/actions/runs/28767932774

### Root cause
In .github/scripts/01-setup-environment.sh, messenger.yaml was copied to ${PROJECT_PATH}/config/packages/messenger.yaml, but docker-compose.yaml bind-mounts ./.docker/messenger.yaml into the php and supervisord containers (lines 50 and 62). Because .docker/messenger.yaml never existed, Docker created a directory at that host path and then failed with 'not a directory' when mounting it onto the file /var/www/html/config/packages/messenger.yaml, aborting container startup.

### What changed
Fixed the copy destination for messenger.yaml in 01-setup-environment.sh from config/packages/messenger.yaml to .docker/messenger.yaml, matching the docker-compose bind-mount source (and the existing pattern used for nginx.conf and supervisord.conf). This lets the php/supervisord containers start so the API tests can run.