### PR TITLE
Fix SBOM branch fan-out: pass --repo to gh workflow run

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -63,7 +63,9 @@ jobs:
             | while IFS= read -r branch; do
                 [ -z "${branch}" ] && continue
                 echo "Dispatching SBOM generation for ${branch}"
-                gh workflow run sbom.yaml --ref "${branch}"
+                # --repo is required: this job has no checkout, so gh cannot
+                # infer the repository from a local git context.
+                gh workflow run sbom.yaml --repo "${GITHUB_REPOSITORY}" --ref "${branch}"
               done
 
   sbom:


### PR DESCRIPTION
## Problem

The nightly `dispatch-branches` job (added in #224) fails:

```
Dispatching SBOM generation for 2026.2
failed to run git: fatal: not a git repository (or any of the parent directories): .git
Process completed with exit code 1
```

Run: https://github.com/pimcore/platform-version/actions/runs/29789921049

## Root cause

The `dispatch-branches` job has no `actions/checkout` step, so there is no local git repository. `gh workflow run` tries to infer the target repo from the git remote and errors out. (The `gh api` calls in the same job work because their repo is embedded in the API path.)

## Fix

Pass the repository to `gh workflow run` explicitly:

```
gh workflow run sbom.yaml --repo "${GITHUB_REPOSITORY}" --ref "${branch}"
```

This is preferred over adding a checkout step (one alternative), which would clone the whole repo purely so `gh` can detect the remote — unnecessary network and time for a job that only makes API calls.

## Note

The `sbom` job itself succeeded in the failing run; only the fan-out step was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)