### PR TITLE
Fix stale reverseObjectRelation owner class in test_ATF

### DIFF
--- a/.github/files/class-definitions/class_automaticTestFull_export.json
+++ b/.github/files/class-definitions/class_automaticTestFull_export.json
@@ -1058,7 +1058,7 @@
                                 "visibleFieldDefinitions": [],
                                 "width": "",
                                 "height": "",
-                                "ownerClassName": "FullAutomaticTest",
+                                "ownerClassName": "automaticTestFull",
                                 "ownerClassId": null,
                                 "ownerFieldName": "manyToOneField",
                                 "lazyLoading": true


### PR DESCRIPTION
 fixture

The automaticTestFull (test_ATF) class fixture defined its reverseObjectRelation field with ownerClassName "FullAutomaticTest", a leftover from a class rename. The real class name is "automaticTestFull", and the owner field (manyToOneField) lives on that class, so this is a self-referential reverse relation whose owner class must be "automaticTestFull".

pimcore/pimcore v2026.2.4 (commit 47b8a32f, #19002 "Prevent database access in ReverseObjectRelation") changed ReverseObjectRelation::getClasses() to guard on $this->ownerClassName instead of $this->getOwnerClassId(). Previously the dangling owner name was silently dropped (getOwnerClassId() resolved via getByName(), failed, returned null -> getClasses() returned []). Now the unresolved name is returned as-is, so the Studio grid column collector (AdvancedColumnCollector::buildRelationFields) calls getClassDefinition("FullAutomaticTest"), which throws NotFound and makes GET /pimcore-studio/api/data-object/grid/available-columns?classId=test_ATF return 404. This broke the API test GetAvailableColumnsForFullClass.

Correcting the fixture data to the real class name resolves the failure and is forward-compatible across all tested platform versions.