### PR TITLE
Merge 2026.2 into 2026.x

### DIFF
--- a/.github/files/class-definitions/class_automaticTestFull_export.json
+++ b/.github/files/class-definitions/class_automaticTestFull_export.json
@@ -1058,7 +1058,7 @@
                                 "visibleFieldDefinitions": [],
                                 "width": "",
                                 "height": "",
-                                "ownerClassName": "FullAutomaticTest",
+                                "ownerClassName": "automaticTestFull",
                                 "ownerClassId": null,
                                 "ownerFieldName": "manyToOneField",
                                 "lazyLoading": true


### PR DESCRIPTION
## Upstream forward-merge: `2026.2` → `2026.x`

Brings the `2026.2` release line forward into `2026.x` (adds 4 commits).

- True forward-merge: first parent is `2026.x`.
- Includes the real fix **#241 — Fix stale reverseObjectRelation owner class in test_ATF**, plus SBOM/build-output churn.
- No source-code conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
